### PR TITLE
Fixes #71: Linked the health post card with a blogging site

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
           <div class="col-lg-4 col-md-6 d-flex align-items-stretch mt-4">
             <div class="icon-box">
               <div class="icon"><i class="fas fa-notes-medical"></i></div>
-              <h4><a href="">Health Post</a></h4>
+              <h4><a href="https://www.medicalnewstoday.com/">Health Post</a></h4>
               <p>Weekly, monthly, yearly or each day, however you like it!</p>
             </div>
           </div>


### PR DESCRIPTION
I linked a public health care related blogging site with the health post card at the Services section so that upon clicking the user will be redirected to that blogging site.