### PR TITLE
Rapidoc header text is moved to right position

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         <div class="img">
         <img src="images/rd.png" width="70" height="80"> 
       </div>
-      <div class="text" style="margin-left: -33rem;">
+      <div class="text" style="margin-left: -20rem;">
   
         <h1 class="logo me-auto"><a style="text-decoration: none; color: #55a5ea;" href="index.html">RapiDoc</a></h1>
       </div>


### PR DESCRIPTION
## Description

The header of the Rapidoc text was not in right position, which it was moved to out of the screen. Now the text is changed to right position. The header is not properly has layout and ordered.

## Related Issues

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]
- Closes #301 

## Type of PR

- [X ] Bug fix
- [x] Feature enhancement
- [x] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]
![image](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/assets/130668745/95a0ccb5-cad8-46f0-bbec-7d41730698b6)


## Checklist

- [ X] I have gone through the [contributing guide](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/)
- [X ] I have updated my branch and synced it with project `main` branch before making this PR
- [ X] I have performed a self-review of my code
- [ X] I have tested the changes thoroughly before submitting this pull request.
- [ X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
The Text or header of the RAPIDOC text was not properly layout. Now the text has moved to correct position by me from changing the margin. You can check the issue which was made by me and compare the both screenshots.
