### PR TITLE
Resolved overlapping issue between chatbot and scroll to top button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1749,8 +1749,8 @@ footer {
 
 #back-to-top-container {
   position: fixed;
-  bottom: 100px;
-  right: 47px;
+  bottom: 25px;
+  left: 30px;
   cursor: pointer;
   z-index: 1000;
 }


### PR DESCRIPTION
Hi @Anishkagupta04 ,
closes #537 

considering the current positioning where the chatbot is in the rightmost bottom of the page and the scroll-to-top button is just above it, I adjusted the scroll-to-top button to be moved to the left side of the page to avoid overlap.

******Video/Screenshots (mandatory)******

Here as you can see :

![image](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/assets/160386036/920d5de4-3511-43ac-acd9-89af9cbf4c69)

Please take a look and also add required labels.