### PR TITLE
Added "Customer Agreement" and "Terms and Conditions" Pages

### DIFF
--- a/Html-Files/customer_agreement.html
+++ b/Html-Files/customer_agreement.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Customer Agreement - RAPIDOC Healthcare</title>
+
+    <link rel="icon" href="https://cdn-icons-png.flaticon.com/256/2666/2666501.png">
+
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <style>
+
+
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: black;
+        }
+
+
+
+        #customer-agreement-container {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 20px;
+            background: #1c413b;
+            color: white;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+
+        }
+
+        #customer-agreement-header {
+            text-align: center;
+            }
+            
+            #customer-agreement-title {
+            color: white;
+            font-size: 2.5em;
+            margin-bottom: 10px;
+        }
+
+
+
+        #customer-agreement-main {
+            margin-top: 20px;
+        }
+
+
+
+        .section-title {
+            color: #00d9ffc2;
+            font-size: 1.5em;
+            margin-top: 20px;
+        }
+
+        .section-content, .section-list {
+            margin: 10px 0;
+        }
+
+        .section-list {
+            list-style: none;
+            padding: 0;
+        }
+
+
+        .list-item {
+            margin-bottom: 10px;
+            font-size: 1.1em;
+        }
+
+
+
+        footer {
+            background-color: black;
+            color: #fff;
+            padding: 20px 0;
+        }
+        footer a {
+            color: #fff;
+            text-decoration: none;
+        }
+        footer a:hover {
+            text-decoration: none;
+            color: gray;
+        }
+        h1, h2 {
+            color: black;
+        }
+    </style>
+
+
+</head>
+
+<body>
+
+    <div class="container" id="customer-agreement-container">
+        <header id="customer-agreement-header">
+            <h1 id="customer-agreement-title">Customer Agreement</h1>
+        </header>
+        <main class="main-content" id="customer-agreement-main">
+            <section class="section" id="customer-agreement-introduction">
+                <h2 class="section-title" id="introduction-title">Introduction</h2>
+                <p class="section-content" id="introduction-content">Welcome to RAPIDOC Healthcare Website. This
+                    Customer Agreement outlines the terms and conditions under which you may use our online platform to
+                    access healthcare information and services. By using our website, you agree to comply with and be
+                    bound by the terms of this agreement.</p>
+            </section>
+            <section class="section" id="customer-agreement-services">
+                <h2 class="section-title" >Services Provided</h2>
+                <ul class="section-list" >
+                    <li class="list-item"><strong>Information Access:</strong> RAPIDOC provides information about the
+                        nearest hospitals and healthcare facilities, including blood availability in emergencies, OPDs,
+                        and bed availability.</li>
+                    <li class="list-item"><strong>Appointment Booking:</strong> Users can prebook appointments for OPDs
+                        at desired hospitals.</li>
+                    <li class="list-item"><strong>Emergency Services:</strong> Information on emergency services and
+                        blood group availability.</li>
+                    <li class="list-item"><strong>Healthcare Facilities:</strong> Detailed information on healthcare
+                        services provided by various hospitals.</li>
+                </ul>
+            </section>
+            <section class="section" id="customer-agreement-responsibilities">
+                <h2 class="section-title" >User Responsibilities</h2>
+                <ul class="section-list" >
+                    <li class="list-item"><strong>Accuracy of Information:</strong> Users must provide accurate and
+                        up-to-date information when using our services.</li>
+                    <li class="list-item"><strong>Compliance:</strong> Users must comply with all applicable laws and
+                        regulations when using our platform.</li>
+                    <li class="list-item"><strong>Account Security:</strong> Users are responsible for maintaining the
+                        confidentiality of their account information and password.</li>
+                </ul>
+            </section>
+            <section class="section" id="customer-agreement-terms">
+                <h2 class="section-title" >Terms of Use</h2>
+                <ul class="section-list">
+                    <li class="list-item"><strong>Acceptance of Terms:</strong> By accessing and using our website, you
+                        accept and agree to be bound by the terms of this Customer Agreement.</li>
+                    <li class="list-item"><strong>Modification of Terms:</strong> RAPIDOC reserves the right to modify
+                        these terms at any time. Any changes will be posted on this page, and your continued use of the
+                        website will constitute acceptance of the new terms.</li>
+                    <li class="list-item"><strong>Termination:</strong> RAPIDOC may terminate your access to the website
+                        at any time, without notice, for conduct that it believes violates this agreement or is harmful
+                        to other users of the website, RAPIDOC, or third parties, or for any other reason.</li>
+                </ul>
+            </section>
+            <section class="section" id="customer-agreement-contact">
+                <h2 class="section-title" >Contact Information</h2>
+                <p class="section-content" >For any questions or concerns about this Customer
+                    Agreement, please contact us at rapidoc@mail.com.</p>
+            </section>
+        </main>
+    </div>
+        <!-- Footer -->
+        <footer class="text-center mt-5">
+            <div class="container">
+                <p>&copy; 2024 RapiDoc. All rights reserved.</p>
+                <ul class="list-inline">
+                    <li class="list-inline-item"><a href="/index.html">Home</a></li>
+                    <li class="list-inline-item"><a href="/Html-Files/privacy_policy_page.html">Privacy Policy</a></li>
+                    <li class="list-inline-item"><a href="/Html-Files/terms_and_conditions.html">Terms and Conditions</a></li>
+                </ul>
+            </div>
+        </footer>
+</body>
+
+</html>

--- a/Html-Files/terms_and_conditions.html
+++ b/Html-Files/terms_and_conditions.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms and Conditions - RAPIDOC Healthcare</title>
+    <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/1458/1458279.png">
+    
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #000;
+        }
+
+        #terms-conditions-container {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 20px;
+            background: #1c413b;
+            border-radius: 8px;
+            color: white;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+
+        #terms-conditions-header {
+            text-align: center;
+        }
+
+        #terms-conditions-title {
+            color: white;
+            font-size: 2.5em;
+            margin-bottom: 10px;
+        }
+
+        #terms-conditions-main {
+            margin-top: 20px;
+        }
+
+        .section-title {
+            color: #00d9ffc2;
+            font-size: 1.5em;
+            margin-top: 20px;
+        }
+
+        .section-content,
+        .section-list {
+            margin: 10px 0;
+        }
+
+        .section-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .list-item {
+            margin-bottom: 10px;
+            font-size: 1.1em;
+        }
+
+
+        footer {
+            background-color: black;
+            color: #fff;
+            padding: 20px 0;
+        }
+        footer a {
+            color: #fff;
+            text-decoration: none;
+        }
+
+        footer a:hover {
+            text-decoration: none;
+            color: gray;
+        }
+
+        h1, h2 {
+            color: black;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container" id="terms-conditions-container">
+        <header class="header" id="terms-conditions-header">
+            <h1 class="title" id="terms-conditions-title">Terms and Conditions</h1>
+        </header>
+        <main class="main-content" id="terms-conditions-main">
+            <section class="section" >
+                <h2 class="section-title" >Introduction</h2>
+                <p class="section-content" >These terms and conditions outline the rules and
+                    regulations for the use of RAPIDOC Healthcare Website. By accessing this website we assume you
+                    accept these terms and conditions. Do not continue to use RAPIDOC Healthcare if you do not agree to
+                    take all of the terms and conditions stated on this page.</p>
+            </section>
+        
+            <section class="section" id="terms-conditions-privacy">
+                <h2 class="section-title" >Privacy</h2>
+                <p class="section-content" >We are committed to protecting your privacy. Please
+                    refer to our Privacy Policy for information on how we collect, use, and disclose your personal
+                    information.</p>
+            </section>
+            <section class="section" id="terms-conditions-license">
+                <h2 class="section-title">License</h2>
+                <p class="section-content" >Unless otherwise stated, RAPIDOC Healthcare and/or its
+                    licensors own the intellectual property rights for all material on RAPIDOC Healthcare. All
+                    intellectual property rights are reserved. You may access this from RAPIDOC Healthcare for your own
+                    personal use subjected to restrictions set in these terms and conditions.</p>
+            </section>
+            <section class="section" id="terms-conditions-conduct">
+                <h2 class="section-title" >User Conduct</h2>
+                <ul class="section-list" >
+                    <li class="list-item">You must not use this website in any way that causes, or may cause, damage to
+                        the website or impairment of the availability or accessibility of the website.</li>
+                    <li class="list-item">You must not use this website in any way which is unlawful, illegal,
+                        fraudulent or harmful, or in connection with any unlawful, illegal, fraudulent or harmful
+                        purpose or activity.</li>
+                    <li class="list-item">You must not use this website to copy, store, host, transmit, send, use,
+                        publish or distribute any material which consists of (or is linked to) any spyware, computer
+                        virus, Trojan horse, worm, keystroke logger, rootkit or other malicious computer software.</li>
+                </ul>
+            </section>
+            <section class="section" id="terms-conditions-changes">
+                <h2 class="section-title">Changes to These Terms</h2>
+                <p class="section-content" >We may update our Terms and Conditions from time to
+                    time. We will notify you of any changes by posting the new Terms and Conditions on this page. You
+                    are advised to review this Terms and Conditions periodically for any changes. Changes to this Terms
+                    and Conditions are effective when they are posted on this page.</p>
+            </section>
+            <section class="section" id="terms-conditions-contact">
+                <h2 class="section-title">Contact Information</h2>
+                <p class="section-content" >If you have any questions about these Terms and
+                    Conditions, please contact us at rapidoc@mail.com.</p>
+            </section>
+        </main>
+    </div>
+        <!-- Footer -->
+        <footer class="text-center mt-5">
+            <div class="container">
+                <p>&copy; 2024 RapiDoc. All rights reserved.</p>
+                <ul class="list-inline">
+                    <li class="list-inline-item"><a href="/index.html">Home</a></li>
+                    <li class="list-inline-item"><a href="/Html-Files/privacy_policy_page.html">Privacy Policy</a></li>
+                    <li class="list-inline-item"><a href="/Html-Files/customer_agreement.html">Customer Agreement</a></li>
+                </ul>
+            </div>
+        </footer>
+    
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1328,9 +1328,9 @@ document.querySelectorAll('.about-us-location').forEach(function(element) {
                 <section>
                   <h4>Legal</h4><br>
                   <ul class="links">
-                    <li><a href="customer_agreement.html">Customer Agreement</a></li>
+                    <li><a href="Html-Files/customer_agreement.html">Customer Agreement</a></li>
                     <li><a href="Html-Files/privacy_policy_page.html">Privacy Policy</a></li>
-                    <li><a href="terms_and_conditions.html">Terms and Conditions</a></li>
+                    <li><a href="Html-Files/terms_and_conditions.html">Terms and Conditions</a></li>
                     <li><a href="#">GDPR</a></li>
                     <li><a href="#">Security</a></li>
                     <li><a href="#test">Testimonials</a></li>

--- a/index.html
+++ b/index.html
@@ -1325,10 +1325,10 @@ document.querySelectorAll('.about-us-location').forEach(function(element) {
                   <h4>Legal</h4><br>
                   <ul class="links">
                     <li><a href="#">Customer Agreement</a></li>
-                    <li><a href="#">Privacy Policy</a></li>
+                    <li><a href="Html-Files/privacy_policy_page.html">Privacy Policy</a></li>
                     <li><a href="#">GDPR</a></li>
                     <li><a href="#">Security</a></li>
-                    <li><a href="#">Testimonials</a></li>
+                    <li><a href="#test">Testimonials</a></li>
                   </ul>
                 </section>
                 <section class="footer-col">

--- a/index.html
+++ b/index.html
@@ -1328,8 +1328,9 @@ document.querySelectorAll('.about-us-location').forEach(function(element) {
                 <section>
                   <h4>Legal</h4><br>
                   <ul class="links">
-                    <li><a href="#">Customer Agreement</a></li>
+                    <li><a href="customer_agreement.html">Customer Agreement</a></li>
                     <li><a href="Html-Files/privacy_policy_page.html">Privacy Policy</a></li>
+                    <li><a href="terms_and_conditions.html">Terms and Conditions</a></li>
                     <li><a href="#">GDPR</a></li>
                     <li><a href="#">Security</a></li>
                     <li><a href="#test">Testimonials</a></li>


### PR DESCRIPTION
Hey @Anishkagupta04 and @varshith257 ,
issue closes #685 

**Below are the Changes I Implemented -** 

-  I **Created two separate HTML pages** for "Customer Agreement" and "Terms and Conditions" and linked them into the footer links
- I tried my very best **to style the two pages** similar to the **website's color theme** so that visually it will look good to see.
- I **also added favicons** to both the pages as you can see in the video below.
- Additionally, I have included a footer at the end of both the pages to re-navigate to the "Home" page instead of changing the tabs manually.

Please take look to the video below - 

https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/assets/131389695/8ce2ba31-c5d9-4e23-b8e8-67394a5d1123


@varshith257 Please review the changes and let me know if any adjustments are needed. Thank you!
I look forward to contribute tmore to your project.


## Type of PR
- [x] Feature enhancement

## Checklist

- [x] I have gone through the [contributing guide](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have performed a self-review of my code
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.