### PR TITLE
Fixed overflowing of text from the cards in about us section .

### DIFF
--- a/Css-Files/aboutus.css
+++ b/Css-Files/aboutus.css
@@ -123,7 +123,7 @@
   flex-direction: column;
   gap: 1rem;
   width: 35%;
-  height: 18rem;
+  height: 19.5rem;
   border: 1px solid rgba(206, 212, 218, 1);
   border-radius: 8px;
   margin-bottom: 21px;


### PR DESCRIPTION
## Description
Fixed overflowing of text from the cards in about us section .
Now the text is within cards and properly aligned on the about us section .
## Related Issues
- Closes #836

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Screenshot (704)](https://github.com/user-attachments/assets/f074b97a-ffdb-48d5-b8f6-e42d61fc51ce)
![Screenshot (705)](https://github.com/user-attachments/assets/d41a6fe2-b314-4875-8ff4-918ed5c21185)



## Checklist

- [x] I have gone through the [contributing guide](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have performed a self-review of my code
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->